### PR TITLE
"Include" parameter field as array

### DIFF
--- a/bin/input_module_pagerduty_api_logentries.py
+++ b/bin/input_module_pagerduty_api_logentries.py
@@ -52,7 +52,7 @@ def collect_events(helper, ew):
 
     def get_entries(since, until, offset):
         params = {
-            #include': ['log_entries','channels','services','teams'],
+            #'include[]': ['log_entries','channels','services','teams'],
             'since': since,
             'until': until,
             "is_overview": "false",


### PR DESCRIPTION
Pagerduty expect receiving an array at "include" parameter.